### PR TITLE
Release v1.2.0: Upper ontologies, segmented controls, UI fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@ venv/
 .venv/
 
 # Python
+uv.lock
 __pycache__/
 *.py[cod]
 *$py.class

--- a/.streamlit/config.toml
+++ b/.streamlit/config.toml
@@ -1,0 +1,2 @@
+[theme]
+primaryColor = "#0D2B7A"

--- a/app.py
+++ b/app.py
@@ -7,7 +7,7 @@ import streamlit as st
 import traceback
 from datetime import datetime
 
-APP_VERSION = "1.1.3"
+APP_VERSION = "1.2.0"
 
 GITHUB_ISSUES_URL = "https://github.com/ralfbecher/orionbelt-ontology-builder/issues"
 
@@ -68,6 +68,11 @@ st.markdown("""
     }
     [data-testid="stCustomComponentV1"] {
         margin-bottom: -1rem !important;
+    }
+    /* Segmented control: logo blue for active segment */
+    [data-testid="stButtonGroup"] button[aria-checked="true"] {
+        background-color: #0D2B7A !important;
+        color: white !important;
     }
 </style>
 """, unsafe_allow_html=True)
@@ -393,9 +398,12 @@ def render_classes():
     classes = ont.get_classes()
     class_names = [c["name"] for c in classes]
 
-    tab1, tab2, tab3, tab4 = st.tabs(["View Classes", "Add Class", "Edit/Delete Class", "Bulk Operations"])
+    _cls_tab = st.segmented_control("Section", ["View Classes", "Add Class", "Edit/Delete Class", "Bulk Operations"],
+                                    default="View Classes", key="cls_active_tab", label_visibility="collapsed")
+    if not _cls_tab:
+        _cls_tab = "View Classes"
 
-    with tab1:
+    if _cls_tab == "View Classes":
         if not classes:
             st.info("No classes defined yet. Add a class to get started.")
         else:
@@ -498,7 +506,7 @@ def render_classes():
                 })
             st.dataframe(class_data, width="stretch")
 
-    with tab2:
+    if _cls_tab == "Add Class":
         st.subheader("Add New Class")
 
         with st.form("add_class_form"):
@@ -522,7 +530,7 @@ def render_classes():
                     show_message(f"Class '{name}' added successfully!", "success")
                     st.rerun()
 
-    with tab3:
+    if _cls_tab == "Edit/Delete Class":
         st.subheader("Edit or Delete Class")
 
         if not classes:
@@ -595,7 +603,7 @@ def render_classes():
                     if not usages["inbound"] and not usages["outbound"]:
                         st.caption("No usages found.")
 
-    with tab4:
+    if _cls_tab == "Bulk Operations":
         import pandas as pd
         bulk_op = st.radio("Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_class_op")
 
@@ -687,12 +695,13 @@ def render_properties():
     obj_prop_names = [p["name"] for p in object_props]
     data_prop_names = [p["name"] for p in data_props]
 
-    tab1, tab2, tab3, tab4, tab5 = st.tabs([
-        "Object Properties", "Data Properties",
-        "Add Object Property", "Add Data Property", "Bulk Operations"
-    ])
+    _prop_tab = st.segmented_control("Section", ["Object Properties", "Data Properties",
+                                     "Add Object Property", "Add Data Property", "Bulk Operations"],
+                                    default="Object Properties", key="prop_active_tab", label_visibility="collapsed")
+    if not _prop_tab:
+        _prop_tab = "Object Properties"
 
-    with tab1:
+    if _prop_tab == "Object Properties":
         st.subheader("Object Properties")
         if not object_props:
             st.info("No object properties defined yet.")
@@ -794,7 +803,7 @@ def render_properties():
                                 show_message(f"Property '{current_name}' updated!", "success")
                                 st.rerun()
 
-    with tab2:
+    if _prop_tab == "Data Properties":
         st.subheader("Data Properties")
         if not data_props:
             st.info("No data properties defined yet.")
@@ -898,7 +907,7 @@ def render_properties():
                                 show_message(f"Property '{current_name}' updated!", "success")
                                 st.rerun()
 
-    with tab3:
+    if _prop_tab == "Add Object Property":
         st.subheader("Add Object Property")
 
         with st.form("add_obj_prop_form"):
@@ -954,7 +963,7 @@ def render_properties():
                     show_message(f"Object property '{name}' added!", "success")
                     st.rerun()
 
-    with tab4:
+    if _prop_tab == "Add Data Property":
         st.subheader("Add Data Property")
 
         with st.form("add_data_prop_form"):
@@ -992,7 +1001,7 @@ def render_properties():
                     show_message(f"Data property '{name}' added!", "success")
                     st.rerun()
 
-    with tab5:
+    if _prop_tab == "Bulk Operations":
         import pandas as pd
         bulk_op = st.radio("Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_prop_op")
 
@@ -1082,9 +1091,12 @@ def render_individuals():
     object_props = ont.get_object_properties()
     data_props = ont.get_data_properties()
 
-    tab1, tab2, tab3, tab4 = st.tabs(["View Individuals", "Add Individual", "Add Property Value", "Bulk Operations"])
+    _ind_tab = st.segmented_control("Section", ["View Individuals", "Add Individual", "Add Property Value", "Bulk Operations"],
+                                    default="View Individuals", key="ind_active_tab", label_visibility="collapsed")
+    if not _ind_tab:
+        _ind_tab = "View Individuals"
 
-    with tab1:
+    if _ind_tab == "View Individuals":
         if not individuals:
             st.info("No individuals defined yet.")
         else:
@@ -1198,7 +1210,7 @@ def render_individuals():
                                 show_message(f"Individual '{current_name}' updated!", "success")
                                 st.rerun()
 
-    with tab2:
+    if _ind_tab == "Add Individual":
         st.subheader("Add Individual")
 
         if not class_names:
@@ -1222,7 +1234,7 @@ def render_individuals():
                         show_message(f"Individual '{name}' added!", "success")
                         st.rerun()
 
-    with tab3:
+    if _ind_tab == "Add Property Value":
         st.subheader("Add Property Value to Individual")
 
         if not individuals:
@@ -1259,7 +1271,7 @@ def render_individuals():
                         show_message(f"Property value added to '{individual}'!", "success")
                         st.rerun()
 
-    with tab4:
+    if _ind_tab == "Bulk Operations":
         import pandas as pd
         bulk_op = st.radio("Operation", ["Add", "Edit", "Delete"], horizontal=True, key="bulk_ind_op")
 
@@ -1342,9 +1354,12 @@ def render_restrictions():
     all_props = [p["name"] for p in object_props] + [p["name"] for p in data_props]
     restrictions = ont.get_restrictions()
 
-    tab1, tab2 = st.tabs(["View Restrictions", "Add Restriction"])
+    _rest_tab = st.segmented_control("Section", ["View Restrictions", "Add Restriction"],
+                                     default="View Restrictions", key="rest_active_tab", label_visibility="collapsed")
+    if not _rest_tab:
+        _rest_tab = "View Restrictions"
 
-    with tab1:
+    if _rest_tab == "View Restrictions":
         if not restrictions:
             st.info("No restrictions defined yet.")
         else:
@@ -1366,7 +1381,7 @@ def render_restrictions():
                             show_message("Restriction deleted!", "success")
                             st.rerun()
 
-    with tab2:
+    if _rest_tab == "Add Restriction":
         st.subheader("Add Restriction")
 
         if not class_names:
@@ -1428,11 +1443,12 @@ def render_relations():
     individuals = ont.get_individuals()
     ind_names = [i["name"] for i in individuals]
 
-    tab1, tab2, tab3, tab4 = st.tabs([
-        "View Relations", "Class Relations", "Property Relations", "Individual Relations"
-    ])
+    _rel_tab = st.segmented_control("Section", ["View Relations", "Class Relations", "Property Relations", "Individual Relations"],
+                                    default="View Relations", key="rel_active_tab", label_visibility="collapsed")
+    if not _rel_tab:
+        _rel_tab = "View Relations"
 
-    with tab1:
+    if _rel_tab == "View Relations":
         st.subheader("All Relations")
 
         # Class relations
@@ -1502,7 +1518,7 @@ def render_relations():
         else:
             st.info("No individual relations defined.")
 
-    with tab2:
+    if _rel_tab == "Class Relations":
         st.subheader("Add Class Relation")
 
         if len(class_names) < 2:
@@ -1538,7 +1554,7 @@ def render_relations():
                         show_message(f"Relation added: {class1} {relation_type} {class2}", "success")
                         st.rerun()
 
-    with tab3:
+    if _rel_tab == "Property Relations":
         st.subheader("Add Property Relation")
 
         if len(all_prop_names) < 2:
@@ -1574,7 +1590,7 @@ def render_relations():
                         show_message(f"Relation added: {prop1} {relation_type} {prop2}", "success")
                         st.rerun()
 
-    with tab4:
+    if _rel_tab == "Individual Relations":
         st.subheader("Add Individual Relation")
 
         if len(ind_names) < 2:
@@ -1643,9 +1659,12 @@ def render_annotations():
     # Sort all resources by display text
     all_resources.sort(key=lambda r: r["display"].lower())
 
-    tab1, tab2, tab3 = st.tabs(["View Annotations", "Add Annotation", "Bulk Edit"])
+    _ann_tab = st.segmented_control("Section", ["View Annotations", "Add Annotation", "Bulk Edit"],
+                                    default="View Annotations", key="ann_active_tab", label_visibility="collapsed")
+    if not _ann_tab:
+        _ann_tab = "View Annotations"
 
-    with tab1:
+    if _ann_tab == "View Annotations":
         if not all_resources:
             st.info("No resources to annotate. Create classes, properties, or individuals first.")
         else:
@@ -1703,7 +1722,7 @@ def render_annotations():
                                     show_message("Annotation deleted!", "success")
                                     st.rerun()
 
-    with tab2:
+    if _ann_tab == "Add Annotation":
         st.subheader("Add Annotation")
 
         if not all_resources:
@@ -1781,7 +1800,7 @@ def render_annotations():
                         show_message("Annotation added!", "success")
                         st.rerun()
 
-    with tab3:
+    if _ann_tab == "Bulk Edit":
         st.subheader("Bulk Edit Annotations")
         st.caption("Edit annotations in a spreadsheet. Add rows to create, mark action as 'delete' to remove.")
 
@@ -1853,11 +1872,12 @@ def render_skos_vocabulary():
     # Clean up unused navigation flag
     st.session_state.pop("_skos_navigate_to_concept", None)
 
-    tab1, tab2, tab3, tab4 = st.tabs([
-        "Concepts", "Concept Schemes", "Concept Hierarchy", "SKOS Validation"
-    ])
+    _skos_tab = st.segmented_control("Section", ["Concepts", "Concept Schemes", "Concept Hierarchy", "SKOS Validation"],
+                                     default="Concepts", key="skos_active_tab", label_visibility="collapsed")
+    if not _skos_tab:
+        _skos_tab = "Concepts"
 
-    with tab2:
+    if _skos_tab == "Concept Schemes":
         st.subheader("Concept Schemes")
         if not schemes:
             st.info("No concept schemes defined yet.")
@@ -1922,7 +1942,7 @@ def render_skos_vocabulary():
                     show_message(f"Scheme '{s_name}' added!", "success")
                     st.rerun()
 
-    with tab1:
+    if _skos_tab == "Concepts":
         st.subheader("Concepts")
         if not concepts:
             st.info("No concepts defined yet.")
@@ -2086,7 +2106,7 @@ def render_skos_vocabulary():
                     show_message(f"Concept '{c_name}' added!", "success")
                     st.rerun()
 
-    with tab3:
+    if _skos_tab == "Concept Hierarchy":
         st.subheader("Concept Hierarchy")
         if not concepts:
             st.info("No concepts to display.")
@@ -2116,7 +2136,7 @@ def render_skos_vocabulary():
             if not roots and hierarchy:
                 st.warning("All concepts have broader concepts — possible cycle.")
 
-    with tab4:
+    if _skos_tab == "SKOS Validation":
         st.subheader("SKOS Validation")
         if st.button("Run SKOS Validation", key="run_skos_validation"):
             issues = ont.validate_skos()
@@ -2138,9 +2158,13 @@ def render_import_export():
 
     ont = st.session_state.ontology
 
-    tab1, tab2, tab3, tab4 = st.tabs(["Import", "Export", "New Ontology", "Templates"])
+    _ie_tabs = ["Import", "Export", "New Ontology", "Templates", "Upper Ontologies"]
+    _ie_tab = st.segmented_control("Section", _ie_tabs, default="Import",
+                                   key="ie_active_tab", label_visibility="collapsed")
+    if not _ie_tab:
+        _ie_tab = "Import"
 
-    with tab1:
+    if _ie_tab == "Import":
         st.subheader("Import Ontology")
 
         # Initialize import preview state
@@ -2156,6 +2180,19 @@ def render_import_export():
         _ont_is_empty = (_stats["classes"] == 0 and _stats["object_properties"] == 0
                          and _stats["data_properties"] == 0 and _stats["individuals"] == 0
                          and _stats.get("concepts", 0) == 0)
+
+        if st.session_state.get("_ontology_cleared"):
+            st.success(st.session_state.pop("_ontology_cleared"))
+
+        with st.popover("Clear Ontology", disabled=_ont_is_empty):
+            st.warning("This will delete all classes, properties, individuals, and triples.")
+            if st.button("Confirm Clear", type="primary", key="clear_ontology_btn"):
+                base_uri = str(ont.namespace)
+                st.session_state.ontology = get_ontology_manager_class()(base_uri=base_uri)
+                from ontology_manager import UndoManager
+                st.session_state.undo_manager = UndoManager(st.session_state.ontology)
+                st.session_state["_ontology_cleared"] = "Ontology cleared!"
+                st.rerun()
 
         def _direct_import(content, format_):
             """Import directly without preview (for empty ontologies)."""
@@ -2377,7 +2414,7 @@ def render_import_export():
                 mime="text/markdown",
             )
 
-    with tab2:
+    if _ie_tab == "Export":
         st.subheader("Export Ontology")
 
         format_options = {
@@ -2414,7 +2451,7 @@ def render_import_export():
             except Exception as e:
                 show_message(f"Error exporting ontology: {str(e)}", "error")
 
-    with tab3:
+    if _ie_tab == "New Ontology":
         st.subheader("Create New Ontology")
 
         st.warning("This will clear the current ontology. Make sure to export first if needed.")
@@ -2442,11 +2479,32 @@ def render_import_export():
                     show_message("New ontology created!", "success")
                     st.rerun()
 
-    with tab4:
+    if _ie_tab == "Templates":
+        from templates import (get_template_names, get_template, render_template)
+
+        def _on_apply_template():
+            selected = st.session_state.template_select
+            mode = st.session_state.template_apply_mode
+            tmpl = get_template(selected)
+            base_uri = str(ont.namespace)
+            rendered = render_template(tmpl, base_uri)
+            if mode == "Replace current":
+                ont.load_from_string(rendered, "turtle")
+            else:
+                ont.merge_from_string(rendered, "turtle")
+            save_checkpoint(f"Apply template: {selected}")
+            s = ont.get_statistics()
+            st.session_state["_template_msg"] = (
+                f"Template '{selected}' applied! "
+                f"— {s['classes']} classes, {s['object_properties']} obj props, "
+                f"{s['data_properties']} data props, {s['content_triples']} triples"
+            )
+
         st.subheader("Apply Template")
         st.caption("Bootstrap your ontology from a built-in template.")
 
-        from templates import get_template_names, get_template, render_template
+        if "_template_msg" in st.session_state:
+            st.success(st.session_state.pop("_template_msg"))
 
         template_names = get_template_names()
         selected_template = st.selectbox("Select Template", template_names, key="template_select")
@@ -2460,20 +2518,95 @@ def render_import_export():
                 rendered = render_template(tmpl, base_uri)
                 st.code(rendered, language="turtle")
 
-            apply_mode = st.radio("Apply Mode",
-                                  ["Merge into current", "Replace current"],
-                                  horizontal=True, key="template_apply_mode")
+            st.radio("Apply Mode",
+                     ["Merge into current", "Replace current"],
+                     horizontal=True, key="template_apply_mode")
 
-            if st.button("Apply Template", type="primary", key="apply_template_btn"):
-                base_uri = str(ont.namespace)
-                rendered = render_template(tmpl, base_uri)
-                if apply_mode == "Replace current":
-                    ont.load_from_string(rendered, "turtle")
-                else:
-                    ont.merge_from_string(rendered, "turtle")
-                save_checkpoint(f"Apply template: {selected_template}")
-                show_message(f"Template '{selected_template}' applied!", "success")
-                st.rerun()
+            st.button("Apply Template", type="primary", key="apply_template_btn",
+                      on_click=_on_apply_template)
+
+    if _ie_tab == "Upper Ontologies":
+        from templates import (get_upper_ontology_names, get_upper_ontology,
+                               load_upper_ontology_module)
+
+        def _on_load_upper_ontology(upper):
+            selected_modules = []
+            for mod in upper["modules"]:
+                if st.session_state.get(f"upper_mod_{mod['name']}", False):
+                    selected_modules.append(mod)
+
+            if not selected_modules:
+                st.session_state["_upper_onto_err"] = "Select at least one module."
+                return
+
+            try:
+                mode = st.session_state.upper_apply_mode
+                first = True
+                for mod in selected_modules:
+                    content = load_upper_ontology_module(mod)
+                    if first and mode == "Replace current":
+                        ont.load_from_string(content, "turtle")
+                        first = False
+                    else:
+                        ont.merge_from_string(content, "turtle")
+                mod_names = ", ".join(m["name"] for m in selected_modules)
+                save_checkpoint(
+                    f"Load upper ontology: {upper['name']} ({mod_names})"
+                )
+                s = ont.get_statistics()
+                st.session_state["_upper_onto_msg"] = (
+                    f"Loaded {upper['name']} ({mod_names})! "
+                    f"— {s['classes']} classes, {s['object_properties']} obj props, "
+                    f"{s['data_properties']} data props, {s['content_triples']} triples"
+                )
+            except Exception as e:
+                st.session_state["_upper_onto_err"] = (
+                    f"Error loading upper ontology: {str(e)}"
+                )
+
+        st.subheader("Upper Ontologies")
+        st.caption(
+            "Start from a professionally built upper ontology as a foundation. "
+            "Your domain classes extend these foundational concepts."
+        )
+
+        if "_upper_onto_msg" in st.session_state:
+            st.success(st.session_state.pop("_upper_onto_msg"))
+        if "_upper_onto_err" in st.session_state:
+            st.error(st.session_state.pop("_upper_onto_err"))
+
+        upper_names = get_upper_ontology_names()
+        selected_upper = st.selectbox("Select Upper Ontology", upper_names,
+                                      key="upper_ontology_select")
+
+        if selected_upper:
+            upper = get_upper_ontology(selected_upper)
+            st.write(f"**{upper['name']}** v{upper['version']}")
+            st.write(upper["description"])
+            st.caption(f"License: {upper['license']} — Attribution: {upper['attribution']}")
+            if upper.get("url"):
+                st.caption(f"More info: {upper['url']}")
+
+            st.write("**Modules:**")
+            for mod in upper["modules"]:
+                default_on = mod.get("required", False) or mod.get("default", False)
+                st.checkbox(
+                    f"**{mod['name']}** — {mod['description']}",
+                    value=default_on,
+                    disabled=mod.get("required", False),
+                    key=f"upper_mod_{mod['name']}",
+                )
+
+            st.radio(
+                "Apply Mode",
+                ["Merge into current", "Replace current"],
+                horizontal=True,
+                key="upper_apply_mode",
+            )
+
+            st.button("Load Upper Ontology", type="primary",
+                      key="apply_upper_ontology_btn",
+                      on_click=_on_load_upper_ontology, args=(upper,))
 
 
 def render_advanced():
@@ -2489,11 +2622,12 @@ def render_advanced():
     individuals = ont.get_individuals()
     ind_names = [i["name"] for i in individuals]
 
-    tab1, tab2, tab3, tab4, tab5 = st.tabs([
-        "Class Expressions", "Property Chains", "Disjoint Union", "All Different", "Has Key"
-    ])
+    _adv_tab = st.segmented_control("Section", ["Class Expressions", "Property Chains", "Disjoint Union", "All Different", "Has Key"],
+                                    default="Class Expressions", key="adv_active_tab", label_visibility="collapsed")
+    if not _adv_tab:
+        _adv_tab = "Class Expressions"
 
-    with tab1:
+    if _adv_tab == "Class Expressions":
         st.subheader("Class Expressions")
         st.caption("Define complex class expressions using set operations")
 
@@ -2549,7 +2683,7 @@ def render_advanced():
                     else:
                         show_message("Please select at least one member!", "error")
 
-    with tab2:
+    if _adv_tab == "Property Chains":
         st.subheader("Property Chains")
         st.caption("Define property chain axioms (e.g., hasParent o hasBrother = hasUncle)")
 
@@ -2586,7 +2720,7 @@ def render_advanced():
                         show_message(f"Property chain added for {result_prop}", "success")
                         st.rerun()
 
-    with tab3:
+    if _adv_tab == "Disjoint Union":
         st.subheader("Disjoint Union")
         st.caption("Define a class as the disjoint union of other classes")
 
@@ -2624,7 +2758,7 @@ def render_advanced():
                         show_message(f"Disjoint union added for {parent_class}", "success")
                         st.rerun()
 
-    with tab4:
+    if _adv_tab == "All Different":
         st.subheader("All Different")
         st.caption("Declare that a set of individuals are all mutually different")
 
@@ -2656,7 +2790,7 @@ def render_advanced():
                         show_message("AllDifferent declaration added!", "success")
                         st.rerun()
 
-    with tab5:
+    if _adv_tab == "Has Key":
         st.subheader("Has Key")
         st.caption("Define key properties that uniquely identify instances of a class")
 
@@ -2699,9 +2833,12 @@ def render_validation():
 
     ont = st.session_state.ontology
 
-    tab1, tab2 = st.tabs(["Validation", "Reasoning"])
+    _val_tab = st.segmented_control("Section", ["Validation", "Reasoning"],
+                                    default="Validation", key="val_active_tab", label_visibility="collapsed")
+    if not _val_tab:
+        _val_tab = "Validation"
 
-    with tab1:
+    if _val_tab == "Validation":
         st.subheader("Ontology Validation")
 
         check_domain_range = st.checkbox(
@@ -2738,7 +2875,7 @@ def render_validation():
                     for issue in infos:
                         st.write(f"  - {issue['message']}")
 
-    with tab2:
+    if _val_tab == "Reasoning":
         st.subheader("Apply Reasoning")
 
         st.write("""
@@ -2781,9 +2918,12 @@ def render_visualization():
         st.info("No content to visualize. Add classes, properties, individuals, or SKOS concepts first.")
         return
 
-    tab1, tab2, tab3 = st.tabs(["Interactive Graph", "Class Hierarchy", "Statistics"])
+    _viz_tab = st.segmented_control("Section", ["Interactive Graph", "Class Hierarchy", "Statistics"],
+                                    default="Interactive Graph", key="viz_active_tab", label_visibility="collapsed")
+    if not _viz_tab:
+        _viz_tab = "Interactive Graph"
 
-    with tab1:
+    if _viz_tab == "Interactive Graph":
         # Row 1: entity type checkboxes + ind. edges + triples
         _has_skos = stats.get("concepts", 0) > 0
         _has_owl = stats["classes"] > 0 or stats["object_properties"] > 0 or stats["data_properties"] > 0
@@ -3389,7 +3529,7 @@ def render_visualization():
                     unsafe_allow_html=True
                 )
 
-    with tab2:
+    if _viz_tab == "Class Hierarchy":
         st.subheader("Class Hierarchy (Text)")
 
         if not classes:
@@ -3420,7 +3560,7 @@ def render_visualization():
             tree_text = build_tree_text(classes)
             st.code(tree_text, language=None)
 
-    with tab3:
+    if _viz_tab == "Statistics":
         st.subheader("Ontology Statistics")
 
         col1, col2 = st.columns(2)

--- a/app.py
+++ b/app.py
@@ -69,11 +69,6 @@ st.markdown("""
     [data-testid="stCustomComponentV1"] {
         margin-bottom: -1rem !important;
     }
-    /* Segmented control: logo blue for active segment */
-    [data-testid="stButtonGroup"] button[aria-checked="true"] {
-        background-color: #0D2B7A !important;
-        color: white !important;
-    }
 </style>
 """, unsafe_allow_html=True)
 
@@ -98,15 +93,12 @@ def init_session_state():
         except ImportError as e:
             st.error(f"Failed to load UndoManager: {e}")
             st.session_state.undo_manager = None
-    if "messages" not in st.session_state:
-        st.session_state.messages = []
     if "flash_message" not in st.session_state:
         st.session_state.flash_message = None
     if "error_log" not in st.session_state:
         st.session_state.error_log = []
-    # On first run with empty ontology, start on Import/Export page
-    if "initial_nav_set" not in st.session_state:
-        st.session_state.initial_nav_set = True
+    # On first run with empty ontology, start on Import/Export page.
+    if "nav_radio" not in st.session_state:
         ont = st.session_state.ontology
         _s = ont.get_statistics()
         if _s["classes"] == 0 and _s["object_properties"] == 0 and _s["data_properties"] == 0 and _s.get("concepts", 0) == 0:
@@ -184,15 +176,13 @@ def format_label_name(name: str, label: str) -> str:
 
 
 def _cb_toggle_view(prefix, name):
-    """Callback: toggle view panel, close edit."""
-    vk = f"view_{prefix}_{name}"
-    st.session_state[vk] = not st.session_state.get(vk, False)
+    """Callback: open view panel, close edit."""
+    st.session_state[f"view_{prefix}_{name}"] = True
     st.session_state[f"edit_{prefix}_{name}"] = False
 
 def _cb_toggle_edit(prefix, name):
-    """Callback: toggle edit panel, close view."""
-    ek = f"edit_{prefix}_{name}"
-    st.session_state[ek] = not st.session_state.get(ek, False)
+    """Callback: open edit panel, close view."""
+    st.session_state[f"edit_{prefix}_{name}"] = True
     st.session_state[f"view_{prefix}_{name}"] = False
 
 def _cb_view_to_edit(prefix, name):
@@ -3652,7 +3642,10 @@ def main():
         st.rerun()
 
     # Handle search navigation
-    nav_override = st.session_state.pop("search_navigate_to", None)
+    nav_override = None
+    if "search_navigate_to" in st.session_state:
+        nav_override = st.session_state.search_navigate_to
+        del st.session_state.search_navigate_to
     if nav_override and nav_override in pages:
         st.session_state["nav_radio"] = nav_override
     selection = st.sidebar.radio("Navigation", list(pages.keys()), key="nav_radio")

--- a/ontology_manager.py
+++ b/ontology_manager.py
@@ -1913,7 +1913,7 @@ class OntologyManager:
                         try:
                             members = list(Collection(self.graph, obj))
                             expr["members"] = [self._local_name(m) for m in members if isinstance(m, URIRef)]
-                        except:
+                        except Exception:
                             pass
 
                     if expr["members"]:
@@ -1940,7 +1940,7 @@ class OntologyManager:
                 try:
                     members = list(Collection(self.graph, members_list))
                     all_diffs.append([self._local_name(m) for m in members if isinstance(m, URIRef)])
-                except:
+                except Exception:
                     pass
         return all_diffs
 
@@ -1967,7 +1967,7 @@ class OntologyManager:
                         "class": subj_name,
                         "properties": [self._local_name(p) for p in props if isinstance(p, URIRef)]
                     })
-                except:
+                except Exception:
                     pass
         return keys
 
@@ -1991,7 +1991,7 @@ class OntologyManager:
                         "class": self._local_name(subj),
                         "members": [self._local_name(m) for m in members if isinstance(m, URIRef)]
                     })
-                except:
+                except Exception:
                     pass
         return unions
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "orionbelt-ontology-builder"
-version = "1.1.3"
+version = "1.2.0"
 description = "A Streamlit application for building, editing, and managing OWL ontologies"
 readme = "README.md"
 license = {text = "BSL-1.1"}

--- a/samples/gist/LICENSE-CC-BY-4.0.txt
+++ b/samples/gist/LICENSE-CC-BY-4.0.txt
@@ -1,0 +1,395 @@
+Attribution 4.0 International
+
+=======================================================================
+
+Creative Commons Corporation ("Creative Commons") is not a law firm and
+does not provide legal services or legal advice. Distribution of
+Creative Commons public licenses does not create a lawyer-client or
+other relationship. Creative Commons makes its licenses and related
+information available on an "as-is" basis. Creative Commons gives no
+warranties regarding its licenses, any material licensed under their
+terms and conditions, or any related information. Creative Commons
+disclaims all liability for damages resulting from their use to the
+fullest extent possible.
+
+Using Creative Commons Public Licenses
+
+Creative Commons public licenses provide a standard set of terms and
+conditions that creators and other rights holders may use to share
+original works of authorship and other material subject to copyright
+and certain other rights specified in the public license below. The
+following considerations are for informational purposes only, are not
+exhaustive, and do not form part of our licenses.
+
+     Considerations for licensors: Our public licenses are
+     intended for use by those authorized to give the public
+     permission to use material in ways otherwise restricted by
+     copyright and certain other rights. Our licenses are
+     irrevocable. Licensors should read and understand the terms
+     and conditions of the license they choose before applying it.
+     Licensors should also secure all rights necessary before
+     applying our licenses so that the public can reuse the
+     material as expected. Licensors should clearly mark any
+     material not subject to the license. This includes other CC-
+     licensed material, or material used under an exception or
+     limitation to copyright. More considerations for licensors:
+    wiki.creativecommons.org/Considerations_for_licensors
+
+     Considerations for the public: By using one of our public
+     licenses, a licensor grants the public permission to use the
+     licensed material under specified terms and conditions. If
+     the licensor's permission is not necessary for any reason--for
+     example, because of any applicable exception or limitation to
+     copyright--then that use is not regulated by the license. Our
+     licenses grant only permissions under copyright and certain
+     other rights that a licensor has authority to grant. Use of
+     the licensed material may still be restricted for other
+     reasons, including because others have copyright or other
+     rights in the material. A licensor may make special requests,
+     such as asking that all changes be marked or described.
+     Although not required by our licenses, you are encouraged to
+     respect those requests where reasonable. More considerations
+     for the public:
+    wiki.creativecommons.org/Considerations_for_licensees
+
+=======================================================================
+
+Creative Commons Attribution 4.0 International Public License
+
+By exercising the Licensed Rights (defined below), You accept and agree
+to be bound by the terms and conditions of this Creative Commons
+Attribution 4.0 International Public License ("Public License"). To the
+extent this Public License may be interpreted as a contract, You are
+granted the Licensed Rights in consideration of Your acceptance of
+these terms and conditions, and the Licensor grants You such rights in
+consideration of benefits the Licensor receives from making the
+Licensed Material available under these terms and conditions.
+
+
+Section 1 -- Definitions.
+
+  a. Adapted Material means material subject to Copyright and Similar
+     Rights that is derived from or based upon the Licensed Material
+     and in which the Licensed Material is translated, altered,
+     arranged, transformed, or otherwise modified in a manner requiring
+     permission under the Copyright and Similar Rights held by the
+     Licensor. For purposes of this Public License, where the Licensed
+     Material is a musical work, performance, or sound recording,
+     Adapted Material is always produced where the Licensed Material is
+     synched in timed relation with a moving image.
+
+  b. Adapter's License means the license You apply to Your Copyright
+     and Similar Rights in Your contributions to Adapted Material in
+     accordance with the terms and conditions of this Public License.
+
+  c. Copyright and Similar Rights means copyright and/or similar rights
+     closely related to copyright including, without limitation,
+     performance, broadcast, sound recording, and Sui Generis Database
+     Rights, without regard to how the rights are labeled or
+     categorized. For purposes of this Public License, the rights
+     specified in Section 2(b)(1)-(2) are not Copyright and Similar
+     Rights.
+
+  d. Effective Technological Measures means those measures that, in the
+     absence of proper authority, may not be circumvented under laws
+     fulfilling obligations under Article 11 of the WIPO Copyright
+     Treaty adopted on December 20, 1996, and/or similar international
+     agreements.
+
+  e. Exceptions and Limitations means fair use, fair dealing, and/or
+     any other exception or limitation to Copyright and Similar Rights
+     that applies to Your use of the Licensed Material.
+
+  f. Licensed Material means the artistic or literary work, database,
+     or other material to which the Licensor applied this Public
+     License.
+
+  g. Licensed Rights means the rights granted to You subject to the
+     terms and conditions of this Public License, which are limited to
+     all Copyright and Similar Rights that apply to Your use of the
+     Licensed Material and that the Licensor has authority to license.
+
+  h. Licensor means the individual(s) or entity(ies) granting rights
+     under this Public License.
+
+  i. Share means to provide material to the public by any means or
+     process that requires permission under the Licensed Rights, such
+     as reproduction, public display, public performance, distribution,
+     dissemination, communication, or importation, and to make material
+     available to the public including in ways that members of the
+     public may access the material from a place and at a time
+     individually chosen by them.
+
+  j. Sui Generis Database Rights means rights other than copyright
+     resulting from Directive 96/9/EC of the European Parliament and of
+     the Council of 11 March 1996 on the legal protection of databases,
+     as amended and/or succeeded, as well as other essentially
+     equivalent rights anywhere in the world.
+
+  k. You means the individual or entity exercising the Licensed Rights
+     under this Public License. Your has a corresponding meaning.
+
+
+Section 2 -- Scope.
+
+  a. License grant.
+
+       1. Subject to the terms and conditions of this Public License,
+          the Licensor hereby grants You a worldwide, royalty-free,
+          non-sublicensable, non-exclusive, irrevocable license to
+          exercise the Licensed Rights in the Licensed Material to:
+
+            a. reproduce and Share the Licensed Material, in whole or
+               in part; and
+
+            b. produce, reproduce, and Share Adapted Material.
+
+       2. Exceptions and Limitations. For the avoidance of doubt, where
+          Exceptions and Limitations apply to Your use, this Public
+          License does not apply, and You do not need to comply with
+          its terms and conditions.
+
+       3. Term. The term of this Public License is specified in Section
+          6(a).
+
+       4. Media and formats; technical modifications allowed. The
+          Licensor authorizes You to exercise the Licensed Rights in
+          all media and formats whether now known or hereafter created,
+          and to make technical modifications necessary to do so. The
+          Licensor waives and/or agrees not to assert any right or
+          authority to forbid You from making technical modifications
+          necessary to exercise the Licensed Rights, including
+          technical modifications necessary to circumvent Effective
+          Technological Measures. For purposes of this Public License,
+          simply making modifications authorized by this Section 2(a)
+          (4) never produces Adapted Material.
+
+       5. Downstream recipients.
+
+            a. Offer from the Licensor -- Licensed Material. Every
+               recipient of the Licensed Material automatically
+               receives an offer from the Licensor to exercise the
+               Licensed Rights under the terms and conditions of this
+               Public License.
+
+            b. No downstream restrictions. You may not offer or impose
+               any additional or different terms or conditions on, or
+               apply any Effective Technological Measures to, the
+               Licensed Material if doing so restricts exercise of the
+               Licensed Rights by any recipient of the Licensed
+               Material.
+
+       6. No endorsement. Nothing in this Public License constitutes or
+          may be construed as permission to assert or imply that You
+          are, or that Your use of the Licensed Material is, connected
+          with, or sponsored, endorsed, or granted official status by,
+          the Licensor or others designated to receive attribution as
+          provided in Section 3(a)(1)(A)(i).
+
+  b. Other rights.
+
+       1. Moral rights, such as the right of integrity, are not
+          licensed under this Public License, nor are publicity,
+          privacy, and/or other similar personality rights; however, to
+          the extent possible, the Licensor waives and/or agrees not to
+          assert any such rights held by the Licensor to the limited
+          extent necessary to allow You to exercise the Licensed
+          Rights, but not otherwise.
+
+       2. Patent and trademark rights are not licensed under this
+          Public License.
+
+       3. To the extent possible, the Licensor waives any right to
+          collect royalties from You for the exercise of the Licensed
+          Rights, whether directly or through a collecting society
+          under any voluntary or waivable statutory or compulsory
+          licensing scheme. In all other cases the Licensor expressly
+          reserves any right to collect such royalties.
+
+
+Section 3 -- License Conditions.
+
+Your exercise of the Licensed Rights is expressly made subject to the
+following conditions.
+
+  a. Attribution.
+
+       1. If You Share the Licensed Material (including in modified
+          form), You must:
+
+            a. retain the following if it is supplied by the Licensor
+               with the Licensed Material:
+
+                 i. identification of the creator(s) of the Licensed
+                    Material and any others designated to receive
+                    attribution, in any reasonable manner requested by
+                    the Licensor (including by pseudonym if
+                    designated);
+
+                ii. a copyright notice;
+
+               iii. a notice that refers to this Public License;
+
+                iv. a notice that refers to the disclaimer of
+                    warranties;
+
+                 v. a URI or hyperlink to the Licensed Material to the
+                    extent reasonably practicable;
+
+            b. indicate if You modified the Licensed Material and
+               retain an indication of any previous modifications; and
+
+            c. indicate the Licensed Material is licensed under this
+               Public License, and include the text of, or the URI or
+               hyperlink to, this Public License.
+
+       2. You may satisfy the conditions in Section 3(a)(1) in any
+          reasonable manner based on the medium, means, and context in
+          which You Share the Licensed Material. For example, it may be
+          reasonable to satisfy the conditions by providing a URI or
+          hyperlink to a resource that includes the required
+          information.
+
+       3. If requested by the Licensor, You must remove any of the
+          information required by Section 3(a)(1)(A) to the extent
+          reasonably practicable.
+
+       4. If You Share Adapted Material You produce, the Adapter's
+          License You apply must not prevent recipients of the Adapted
+          Material from complying with this Public License.
+
+
+Section 4 -- Sui Generis Database Rights.
+
+Where the Licensed Rights include Sui Generis Database Rights that
+apply to Your use of the Licensed Material:
+
+  a. for the avoidance of doubt, Section 2(a)(1) grants You the right
+     to extract, reuse, reproduce, and Share all or a substantial
+     portion of the contents of the database;
+
+  b. if You include all or a substantial portion of the database
+     contents in a database in which You have Sui Generis Database
+     Rights, then the database in which You have Sui Generis Database
+     Rights (but not its individual contents) is Adapted Material; and
+
+  c. You must comply with the conditions in Section 3(a) if You Share
+     all or a substantial portion of the contents of the database.
+
+For the avoidance of doubt, this Section 4 supplements and does not
+replace Your obligations under this Public License where the Licensed
+Rights include other Copyright and Similar Rights.
+
+
+Section 5 -- Disclaimer of Warranties and Limitation of Liability.
+
+  a. UNLESS OTHERWISE SEPARATELY UNDERTAKEN BY THE LICENSOR, TO THE
+     EXTENT POSSIBLE, THE LICENSOR OFFERS THE LICENSED MATERIAL AS-IS
+     AND AS-AVAILABLE, AND MAKES NO REPRESENTATIONS OR WARRANTIES OF
+     ANY KIND CONCERNING THE LICENSED MATERIAL, WHETHER EXPRESS,
+     IMPLIED, STATUTORY, OR OTHER. THIS INCLUDES, WITHOUT LIMITATION,
+     WARRANTIES OF TITLE, MERCHANTABILITY, FITNESS FOR A PARTICULAR
+     PURPOSE, NON-INFRINGEMENT, ABSENCE OF LATENT OR OTHER DEFECTS,
+     ACCURACY, OR THE PRESENCE OR ABSENCE OF ERRORS, WHETHER OR NOT
+     KNOWN OR DISCOVERABLE. WHERE DISCLAIMERS OF WARRANTIES ARE NOT
+     ALLOWED IN FULL OR IN PART, THIS DISCLAIMER MAY NOT APPLY TO YOU.
+
+  b. TO THE EXTENT POSSIBLE, IN NO EVENT WILL THE LICENSOR BE LIABLE
+     TO YOU ON ANY LEGAL THEORY (INCLUDING, WITHOUT LIMITATION,
+     NEGLIGENCE) OR OTHERWISE FOR ANY DIRECT, SPECIAL, INDIRECT,
+     INCIDENTAL, CONSEQUENTIAL, PUNITIVE, EXEMPLARY, OR OTHER LOSSES,
+     COSTS, EXPENSES, OR DAMAGES ARISING OUT OF THIS PUBLIC LICENSE OR
+     USE OF THE LICENSED MATERIAL, EVEN IF THE LICENSOR HAS BEEN
+     ADVISED OF THE POSSIBILITY OF SUCH LOSSES, COSTS, EXPENSES, OR
+     DAMAGES. WHERE A LIMITATION OF LIABILITY IS NOT ALLOWED IN FULL OR
+     IN PART, THIS LIMITATION MAY NOT APPLY TO YOU.
+
+  c. The disclaimer of warranties and limitation of liability provided
+     above shall be interpreted in a manner that, to the extent
+     possible, most closely approximates an absolute disclaimer and
+     waiver of all liability.
+
+
+Section 6 -- Term and Termination.
+
+  a. This Public License applies for the term of the Copyright and
+     Similar Rights licensed here. However, if You fail to comply with
+     this Public License, then Your rights under this Public License
+     terminate automatically.
+
+  b. Where Your right to use the Licensed Material has terminated under
+     Section 6(a), it reinstates:
+
+       1. automatically as of the date the violation is cured, provided
+          it is cured within 30 days of Your discovery of the
+          violation; or
+
+       2. upon express reinstatement by the Licensor.
+
+     For the avoidance of doubt, this Section 6(b) does not affect any
+     right the Licensor may have to seek remedies for Your violations
+     of this Public License.
+
+  c. For the avoidance of doubt, the Licensor may also offer the
+     Licensed Material under separate terms or conditions or stop
+     distributing the Licensed Material at any time; however, doing so
+     will not terminate this Public License.
+
+  d. Sections 1, 5, 6, 7, and 8 survive termination of this Public
+     License.
+
+
+Section 7 -- Other Terms and Conditions.
+
+  a. The Licensor shall not be bound by any additional or different
+     terms or conditions communicated by You unless expressly agreed.
+
+  b. Any arrangements, understandings, or agreements regarding the
+     Licensed Material not stated herein are separate from and
+     independent of the terms and conditions of this Public License.
+
+
+Section 8 -- Interpretation.
+
+  a. For the avoidance of doubt, this Public License does not, and
+     shall not be interpreted to, reduce, limit, restrict, or impose
+     conditions on any use of the Licensed Material that could lawfully
+     be made without permission under this Public License.
+
+  b. To the extent possible, if any provision of this Public License is
+     deemed unenforceable, it shall be automatically reformed to the
+     minimum extent necessary to make it enforceable. If the provision
+     cannot be reformed, it shall be severed from this Public License
+     without affecting the enforceability of the remaining terms and
+     conditions.
+
+  c. No term or condition of this Public License will be waived and no
+     failure to comply consented to unless expressly agreed to by the
+     Licensor.
+
+  d. Nothing in this Public License constitutes or may be interpreted
+     as a limitation upon, or waiver of, any privileges and immunities
+     that apply to the Licensor or You, including from the legal
+     processes of any jurisdiction or authority.
+
+
+=======================================================================
+
+Creative Commons is not a party to its public
+licenses. Notwithstanding, Creative Commons may elect to apply one of
+its public licenses to material it publishes and in those instances
+will be considered the “Licensor.” The text of the Creative Commons
+public licenses is dedicated to the public domain under the CC0 Public
+Domain Dedication. Except for the limited purpose of indicating that
+material is shared under a Creative Commons public license or as
+otherwise permitted by the Creative Commons policies published at
+creativecommons.org/policies, Creative Commons does not authorize the
+use of the trademark "Creative Commons" or any other trademark or logo
+of Creative Commons without its prior written consent including,
+without limitation, in connection with any unauthorized modifications
+to any of its public licenses or any other arrangements,
+understandings, or agreements concerning use of licensed material. For
+the avoidance of doubt, this paragraph does not form part of the
+public licenses.
+
+Creative Commons may be contacted at creativecommons.org.

--- a/templates.py
+++ b/templates.py
@@ -1,6 +1,5 @@
 """Built-in ontology templates for bootstrapping new ontologies."""
 
-import os
 from pathlib import Path
 
 TEMPLATES = [

--- a/templates.py
+++ b/templates.py
@@ -1,5 +1,8 @@
 """Built-in ontology templates for bootstrapping new ontologies."""
 
+import os
+from pathlib import Path
+
 TEMPLATES = [
     {
         "name": "Organization",
@@ -329,3 +332,70 @@ def get_template(name: str) -> dict:
 def render_template(template: dict, base_uri: str) -> str:
     """Render a template's Turtle with the given base URI."""
     return template["turtle"].replace("{base_uri}", base_uri)
+
+
+SAMPLES_DIR = Path(__file__).parent / "samples"
+
+UPPER_ONTOLOGIES = [
+    {
+        "name": "gist (Semantic Arts)",
+        "version": "14.1.0",
+        "description": (
+            "A minimalist upper ontology for the enterprise by Semantic Arts. "
+            "Covers ~100 foundational classes (Event, Person, Organization, "
+            "Agreement, Specification, etc.) and ~100 properties. "
+            "Licensed under CC BY 4.0."
+        ),
+        "url": "https://www.semanticarts.com/gist/",
+        "license": "Creative Commons Attribution 4.0 International (CC BY 4.0)",
+        "attribution": "Semantic Arts, Inc.",
+        "modules": [
+            {
+                "name": "gistCore",
+                "file": "gist/gistCore14.1.0.ttl",
+                "description": "Main ontology with all classes, properties, and restrictions",
+                "required": True,
+            },
+            {
+                "name": "gistRdfsAnnotations",
+                "file": "gist/gistRdfsAnnotations14.1.0.ttl",
+                "description": "rdfs:label and rdfs:comment annotations for compatibility",
+                "required": False,
+                "default": True,
+            },
+            {
+                "name": "gistSubClassAssertions",
+                "file": "gist/gistSubClassAssertions14.1.0.ttl",
+                "description": "Materialized subclass inferences (useful without a DL reasoner)",
+                "required": False,
+                "default": True,
+            },
+            {
+                "name": "gistMediaTypes",
+                "file": "gist/gistMediaTypes14.1.0.ttl",
+                "description": "Common internet media type instances",
+                "required": False,
+                "default": False,
+            },
+        ],
+    },
+]
+
+
+def get_upper_ontology_names() -> list:
+    """Return list of upper ontology names."""
+    return [o["name"] for o in UPPER_ONTOLOGIES]
+
+
+def get_upper_ontology(name: str) -> dict:
+    """Return an upper ontology definition by name, or None if not found."""
+    for o in UPPER_ONTOLOGIES:
+        if o["name"] == name:
+            return o
+    return None
+
+
+def load_upper_ontology_module(module: dict) -> str:
+    """Load a module's Turtle content from file."""
+    file_path = SAMPLES_DIR / module["file"]
+    return file_path.read_text(encoding="utf-8")

--- a/tests/test_diff.py
+++ b/tests/test_diff.py
@@ -13,13 +13,6 @@ def base_om():
     m.add_class("Dog", parent="Animal", label="Dog")
     return m
 
-
-def _make_graph_from(ttl: str) -> Graph:
-    g = Graph()
-    g.parse(data=ttl, format="turtle")
-    return g
-
-
 class TestCompareGraphs:
     def test_identical_graphs_produce_empty_diff(self, base_om):
         other = Graph()

--- a/tests/test_merge.py
+++ b/tests/test_merge.py
@@ -96,7 +96,7 @@ class TestMergeOverwriteStrategy:
         # The label should be overwritten to the incoming value
         person_uri = URIRef("http://test.org/ont#Person")
         labels = list(base_om.graph.objects(person_uri, RDFS.label))
-        label_strs = [str(l) for l in labels]
+        label_strs = [str(label) for label in labels]
         assert "Human Being" in label_strs
         assert result["conflicts_resolved"] > 0
 

--- a/tests/test_templates.py
+++ b/tests/test_templates.py
@@ -2,7 +2,9 @@
 
 import pytest
 from rdflib import Graph
-from templates import get_template_names, get_template, render_template
+from templates import (get_template_names, get_template, render_template,
+                       get_upper_ontology_names, get_upper_ontology,
+                       load_upper_ontology_module)
 from ontology_manager import OntologyManager
 
 
@@ -69,3 +71,54 @@ class TestTemplateApplication:
         assert len(schemes) >= 1
         concepts = om.get_concepts()
         assert len(concepts) >= 5
+
+
+class TestUpperOntologies:
+    def test_upper_ontology_names(self):
+        names = get_upper_ontology_names()
+        assert "gist (Semantic Arts)" in names
+
+    def test_get_upper_ontology(self):
+        upper = get_upper_ontology("gist (Semantic Arts)")
+        assert upper is not None
+        assert upper["version"] == "14.1.0"
+        assert len(upper["modules"]) == 4
+
+    def test_get_nonexistent_upper_ontology(self):
+        assert get_upper_ontology("Nonexistent") is None
+
+    def test_load_gist_core_module(self):
+        upper = get_upper_ontology("gist (Semantic Arts)")
+        core = next(m for m in upper["modules"] if m["name"] == "gistCore")
+        content = load_upper_ontology_module(core)
+        assert "@prefix gist:" in content
+        assert "owl:Class" in content
+
+    def test_gist_core_valid_turtle(self):
+        upper = get_upper_ontology("gist (Semantic Arts)")
+        core = next(m for m in upper["modules"] if m["name"] == "gistCore")
+        content = load_upper_ontology_module(core)
+        g = Graph()
+        g.parse(data=content, format="turtle")
+        assert len(g) > 100
+
+    def test_merge_gist_into_ontology(self):
+        om = OntologyManager(base_uri="http://test.org/myont#")
+        om.add_class("MyClass")
+        upper = get_upper_ontology("gist (Semantic Arts)")
+        for mod in upper["modules"]:
+            if mod.get("required") or mod.get("default"):
+                content = load_upper_ontology_module(mod)
+                om.merge_from_string(content, "turtle")
+        classes = [c["name"] for c in om.get_classes()]
+        assert "MyClass" in classes
+        assert "Organization" in classes
+        assert "Event" in classes
+        assert "Person" in classes
+        assert len(classes) > 90
+
+    def test_gist_has_required_module(self):
+        upper = get_upper_ontology("gist (Semantic Arts)")
+        required = [m for m in upper["modules"] if m.get("required")]
+        assert len(required) == 1
+        assert required[0]["name"] == "gistCore"

--- a/tests/test_undo.py
+++ b/tests/test_undo.py
@@ -76,7 +76,8 @@ def test_multiple_undo_redo(populated_om):
     populated_om.add_class("Step3")
     um.checkpoint("Step3")
 
-    names = lambda: [c["name"] for c in populated_om.get_classes()]
+    def names():
+        return [c["name"] for c in populated_om.get_classes()]
 
     assert "Step3" in names()
     um.undo()


### PR DESCRIPTION
## Summary
- **Upper Ontologies tab**: Add gist (Semantic Arts) upper ontology with module selection on the Import/Export page
- **Segmented controls**: Replace all `st.tabs` with `st.segmented_control` across all pages to fix tab state loss on rerun and provide consistent branded UI
- **Theme**: Add `.streamlit/config.toml` with ORIONBELT logo blue (`#0D2B7A`) as primary color
- **View/Edit buttons**: Make idempotent (open only, never toggle closed) — fixes dropdown closing when clicking View after navigating from graph viz
- **Code cleanup**: Replace bare `except:` with `except Exception:`, remove unused imports/dead code, fix variable shadowing in tests

## Test plan
- [ ] Verify segmented controls appear with blue highlight on all pages
- [ ] Apply a template on an empty ontology — tab should stay on Templates, Quick Stats and Clear Ontology should update
- [ ] Load an upper ontology from the new Upper Ontologies tab
- [ ] Navigate from graph viz node → View → click View again — should stay open
- [ ] Run `pytest` — all tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)